### PR TITLE
Simplify library search and initialization

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 - Jochen Broz <jochen.broz@imail.de>
 - Matt Phair <mphair@plexium.com>
 - James Noss <jnoss@stsci.edu>
+- Jose I Romero <jose.cyborg@gmail.com>


### PR DESCRIPTION
Use the facilities supplied by ctypes to find the library. Also
initialize the library at import time. that is guaranteed to only run
once. The init function is kept as a backwards compatible extension
for the cases where the user is explicitly setting the library
filename.